### PR TITLE
feat(grpcbin) add grpcbin

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ The following containers will be created:
 - kong-tests-cassandra
 - kong-tests-postgres
 - kong-tests-redis
+- kong-tests-grpcbin
 
 ### Usage
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,3 +18,10 @@ redis:
   container_name: kong-tests-redis
   ports:
     - "6379:6379"
+
+grpcbin:
+  image: moul/grpcbin
+  container_name: kong-tests-grpcbin
+  ports:
+    - "15002:9000"
+    - "15003:9001"


### PR DESCRIPTION
This adds grpcbin as a dependency, which is needed in most GRPC-related tests in Kong.