### PR TITLE
chore(cassandra): bump cassandra to 3.11

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   cassandra:
-    image: cassandra:3.9
+    image: cassandra:3.11
     container_name: kong-tests-cassandra
     ports:
       - "9042:9042"


### PR DESCRIPTION
This pull request bumps Cassandra from `3.9` to `3.11` to fix the following error with Docker for Mac on Apple Silicon Chips.

```
runtime: failed to create new OS thread (have 2 already; errno=22)
fatal error: newosproc

runtime stack:
runtime.throw(0x524da0, 0x9)
	/usr/local/go/src/runtime/panic.go:527 +0x90
runtime.newosproc(0xc820028000, 0xc820037fc0)
	/usr/local/go/src/runtime/os1_linux.go:150 +0x1ab
runtime.newm(0x555ce8, 0x0)
	/usr/local/go/src/runtime/proc1.go:1105 +0x130
runtime.main.func1()
	/usr/local/go/src/runtime/proc.go:48 +0x2c
runtime.systemstack(0x5c4300)
	/usr/local/go/src/runtime/asm_amd64.s:262 +0x79
runtime.mstart()
	/usr/local/go/src/runtime/proc1.go:674

goroutine 1 [running]:
runtime.systemstack_switch()
	/usr/local/go/src/runtime/asm_amd64.s:216 fp=0xc820022770 sp=0xc820022768
runtime.main()
	/usr/local/go/src/runtime/proc.go:49 +0x62 fp=0xc8200227c0 sp=0xc820022770
runtime.goexit()
	/usr/local/go/src/runtime/asm_amd64.s:1696 +0x1 fp=0xc8200227c8 sp=0xc8200227c0
```

See also:

- https://github.com/docker/for-mac/issues/6083
- https://github.com/docker/for-mac/issues/6137
